### PR TITLE
chore: rename sdk constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,18 +83,19 @@ pnpm add @strapi/sdk-js
 To interact with your Strapi backend, initialize the SDK with your Strapi API base URL:
 
 ```typescript
-import { createStrapiSDK } from '@strapi/sdk-js';
+import { strapiSDK } from '@strapi/sdk-js';
 
-const sdk = createStrapiSDK({ baseURL: 'http://localhost:1337/api' });
+const sdk = strapiSDK({ baseURL: 'http://localhost:1337/api' });
 ```
 
 Alternatively, use a `<script>` tag in a browser environment:
 
 ```html
+
 <script src="https://cdn.jsdelivr.net/npm/@strapi/sdk-js"></script>
 
 <script>
-  const sdk = createStrapiSDK({ baseURL: 'http://localhost:1337/api' });
+    const sdk = strapiSDK({baseURL: 'http://localhost:1337/api'});
 </script>
 ```
 
@@ -107,7 +108,7 @@ The SDK supports multiple authentication strategies for accessing authenticated 
 If your Strapi instance uses API tokens, configure the SDK like this:
 
 ```typescript
-const sdk = createStrapiSDK({
+const sdk = strapiSDK({
   baseURL: 'http://localhost:1337/api',
   auth: {
     strategy: 'api-token',
@@ -204,7 +205,7 @@ await homepage.delete();
 Here’s how to combine `.collection()` and `.single()` methods in a real-world scenario:
 
 ```typescript
-const sdk = createStrapiSDK({
+const sdk = strapiSDK({
   baseURL: 'http://localhost:1337/api',
   auth: {
     strategy: 'api-token',

--- a/README.md
+++ b/README.md
@@ -91,11 +91,10 @@ const sdk = strapiSDK({ baseURL: 'http://localhost:1337/api' });
 Alternatively, use a `<script>` tag in a browser environment:
 
 ```html
-
 <script src="https://cdn.jsdelivr.net/npm/@strapi/sdk-js"></script>
 
 <script>
-    const sdk = strapiSDK({baseURL: 'http://localhost:1337/api'});
+  const sdk = strapiSDK({ baseURL: 'http://localhost:1337/api' });
 </script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ The `.single()` method provides a manager for working with single-type resources
 const homepage = sdk.single('homepage');
 
 // Fetch the default version of the homepage
-const homepageContent = await homepage.find();
+const defaultHomepage = await homepage.find();
 
 // Fetch the spanish version of the homepage
-const homepageContent = await homepage.find({ locale: 'es' });
+const spanishHomepage = await homepage.find({ locale: 'es' });
 
 // Update the homepage draft content
 const updatedHomepage = await homepage.update(

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export * from './errors';
  * };
  *
  * // Create the SDK instance
- * const strapiSDK = createStrapiSDK(sdkConfig);
+ * const strapiSDK = strapiSDK(sdkConfig);
  *
  * // Using the SDK to fetch content from a custom endpoint
  * const response = await strapiSDK.fetch('/content-endpoint');
@@ -44,7 +44,7 @@ export * from './errors';
  * @throws {StrapiSDKInitializationError} If the provided baseURL does not conform to a valid HTTP or HTTPS URL,
  *                                        or if the auth configuration is invalid.
  */
-export const createStrapiSDK = (config: StrapiSDKConfig) => {
+export const strapiSDK = (config: StrapiSDKConfig) => {
   const sdkValidator = new StrapiSDKValidator();
 
   return new StrapiSDK<typeof config>(

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -158,7 +158,7 @@ export class StrapiSDK<const T_Config extends StrapiSDKConfig = StrapiSDKConfig>
    * @example
    * ```typescript
    * // Create the SDK instance
-   * const sdk = createStrapiSDK({ baseURL: 'http://localhost:1337/api' );
+   * const sdk = strapiSDK({ baseURL: 'http://localhost:1337/api' );
    *
    * // Perform a custom fetch query
    * const response = await sdk.fetch('/categories');

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,15 +1,15 @@
-import { createStrapiSDK, StrapiSDKInitializationError, StrapiSDKValidationError } from '../../src';
+import { strapiSDK, StrapiSDKInitializationError, StrapiSDKValidationError } from '../../src';
 import { StrapiSDK } from '../../src/sdk';
 
 import type { StrapiSDKConfig } from '../../src/sdk';
 
-describe('createStrapiSDK', () => {
+describe('strapiSDK', () => {
   it('should create an SDK instance with valid configuration', () => {
     // Arrange
     const config = { baseURL: 'https://api.example.com' } satisfies StrapiSDKConfig;
 
     // Act
-    const sdkInstance = createStrapiSDK(config);
+    const sdkInstance = strapiSDK(config);
 
     // Assert
     expect(sdkInstance).toBeInstanceOf(StrapiSDK);
@@ -21,7 +21,7 @@ describe('createStrapiSDK', () => {
     const config = { baseURL: 'invalid-url' } satisfies StrapiSDKConfig;
 
     // Act & Assert
-    expect(() => createStrapiSDK(config)).toThrow(StrapiSDKInitializationError);
+    expect(() => strapiSDK(config)).toThrow(StrapiSDKInitializationError);
   });
 
   it('should throw an error if auth configuration is invalid', () => {
@@ -35,6 +35,6 @@ describe('createStrapiSDK', () => {
     } satisfies StrapiSDKConfig;
 
     // Act & Assert
-    expect(() => createStrapiSDK(config)).toThrow(StrapiSDKValidationError);
+    expect(() => strapiSDK(config)).toThrow(StrapiSDKValidationError);
   });
 });


### PR DESCRIPTION
**Description:**

### What does it do?

- Renamed `createStrapiSDK` function to `strapiSDK`.
- Fixed formatting in README code example (that were considered errors).

### Why is it needed?

Align with other SDK conventions

### Related issue(s)/PR(s)

N/A