### PR TITLE
fix: add string array to populate type

### DIFF
--- a/src/types/content-api.ts
+++ b/src/types/content-api.ts
@@ -67,9 +67,10 @@ export interface BaseQueryParams {
    *
    * Can be:
    * - a `string` to specify relation paths as `populate=name`
+   * - an `array` of strings to specify multiple relation paths
    * - an `object` to enable deeper population configurations
    */
-  populate?: string | Record<string, unknown>;
+  populate?: string | string[] | Record<string, unknown>;
 
   /**
    * Specifies the fields of documents to include in the response.


### PR DESCRIPTION
### What does it do?

Adds string[] type to populate types.

### Why is it needed?

String `arrays` is already supported by the populate attributes, but the typings just didn't support it yet.

### How to test it?

Should build als usual, a missing type has been added to support already existing functionality.

### Related issue(s)/PR(s)

#26
