### PR TITLE
fix(interceptors): prevent overriding existing headers

### DIFF
--- a/src/interceptors/http.ts
+++ b/src/interceptors/http.ts
@@ -26,8 +26,16 @@ export class HttpInterceptors {
    *```
    */
   public static setDefaultHeaders(): RequestInterceptor {
+    const DEFAULT_HEADERS = new Map([['Content-Type', 'application/json']]);
+
     return ({ request }) => {
-      request.headers.set('Content-Type', 'application/json');
+      for (const [key, value] of DEFAULT_HEADERS.entries()) {
+        const hasHeader = request.headers.has(key);
+
+        if (!hasHeader) {
+          request.headers.set(key, value);
+        }
+      }
 
       return { request };
     };

--- a/tests/unit/interceptors/http.test.ts
+++ b/tests/unit/interceptors/http.test.ts
@@ -16,7 +16,7 @@ describe('HTTP Interceptors', () => {
       expect(request.headers.get('Content-Type')).toBe('application/json');
     });
 
-    it('should override the headers in the given request', async () => {
+    it('should not override the headers if a value is already set', async () => {
       // Arrange
       const request = new Request('https://example.com', {
         headers: { 'Content-Type': 'text/plain' },
@@ -28,7 +28,7 @@ describe('HTTP Interceptors', () => {
       await interceptor({ request });
 
       // Assert
-      expect(request.headers.get('Content-Type')).toBe('application/json');
+      expect(request.headers.get('Content-Type')).toBe('text/plain');
     });
   });
 

--- a/tests/unit/interceptors/http.test.ts
+++ b/tests/unit/interceptors/http.test.ts
@@ -30,6 +30,21 @@ describe('HTTP Interceptors', () => {
       // Assert
       expect(request.headers.get('Content-Type')).toBe('text/plain');
     });
+
+    it('should perform case insensitive checks on headers', async () => {
+      // Arrange
+      const request = new Request('https://example.com', {
+        headers: { 'content-type': 'text/plain' },
+      });
+
+      const interceptor = HttpInterceptors.setDefaultHeaders();
+
+      // Act
+      await interceptor({ request });
+
+      // Assert
+      expect(request.headers.get('Content-Type')).toBe('text/plain');
+    });
   });
 
   describe('transformErrors', () => {

--- a/tests/unit/sdk.test.ts
+++ b/tests/unit/sdk.test.ts
@@ -192,6 +192,34 @@ describe('Strapi', () => {
         expect((headers as Headers).get('Content-Type')).toBe('application/json');
       });
 
+      it('should not set the application/json Content-Type header if it has been manually set', async () => {
+        // Arrange
+        const path = '/upload';
+        const contentType = 'multipart/form-data';
+
+        const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiConfig;
+        const init = {
+          method: 'POST',
+          headers: { 'Content-Type': contentType },
+        } satisfies RequestInit;
+
+        const mockValidator = new MockStrapiConfigValidator();
+        const mockAuthManager = new MockAuthManager();
+
+        const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+
+        const fetchSpy = jest.spyOn(MockHttpClient.prototype, 'fetch');
+
+        // Act
+        await sdk.fetch(path, init);
+        const headers = fetchSpy.mock.lastCall?.[1]?.headers;
+
+        // Assert
+        expect(headers).toBeDefined();
+        expect(headers).toBeInstanceOf(Headers);
+        expect((headers as Headers).get('Content-Type')).toBe(contentType);
+      });
+
       it.each([
         ['Bad Request', StatusCode.BAD_REQUEST, HTTPBadRequestError],
         ['Unauthorized', StatusCode.UNAUTHORIZED, HTTPAuthorizationError],


### PR DESCRIPTION
### What does it do?

Make sure the `setDefaultHeaders` HTTP interceptor doesn't override manually set headers.

### Why is it needed?

see https://github.com/strapi/sdk-js/issues/27

### How to test it?

Using `sdk.fetch` with a custom content type header should not override said header with `application/json`

Alternatively, running the unit tests ensures the behavior is correct based on `tests/unit/sdk.test.ts` and `tests/unit/sdk.test.ts`

### Related issue(s)/PR(s)

fix #27
