### PR TITLE
feat(auth): refactor auth configuration logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,10 @@ If your Strapi instance uses API tokens, configure the SDK like this:
 
 ```typescript
 const sdk = strapi({
+  // Endpoint configuration
   baseURL: 'http://localhost:1337/api',
-  auth: {
-    strategy: 'api-token',
-    options: { token: 'your-api-token-here' },
-  },
+  // Auth configuration
+  auth: 'your-api-token-here',
 });
 ```
 
@@ -248,7 +247,6 @@ Below is a list of available namespaces to use:
 | `strapi:auth:factory`                    | Logs the registration and creation of authentication providers.                           |
 | `strapi:auth:manager`                    | Logs authentication lifecycle management.                                                 |
 | `strapi:auth:provider:api-token`         | Logs operations related to API token authentication.                                      |
-| `strapi:auth:provider:users-permissions` | Logs operations related to user and permissions-based authentication.                     |
 | `strapi:ct:collection`                   | Logs interactions with collection-type content managers.                                  |
 | `strapi:ct:single`                       | Logs interactions with single-type content managers.                                      |
 | `strapi:utils:url-helper`                | Logs URL helper utility operations (e.g., appending query parameters or formatting URLs). |

--- a/README.md
+++ b/README.md
@@ -238,15 +238,15 @@ The `debug` tool allows you to control logs using wildcard patterns (`*`):
 
 Below is a list of available namespaces to use:
 
-| Namespace                                | Description                                                                               |
-| ---------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `strapi:core`                            | Logs SDK initialization, configuration validation, and HTTP client setup.                 |
-| `strapi:validators:config`               | Logs details related to SDK configuration validation.                                     |
-| `strapi:validators:url`                  | Logs URL validation processes.                                                            |
-| `strapi:http`                            | Logs HTTP client setup, request processing, and response/error handling.                  |
-| `strapi:auth:factory`                    | Logs the registration and creation of authentication providers.                           |
-| `strapi:auth:manager`                    | Logs authentication lifecycle management.                                                 |
-| `strapi:auth:provider:api-token`         | Logs operations related to API token authentication.                                      |
-| `strapi:ct:collection`                   | Logs interactions with collection-type content managers.                                  |
-| `strapi:ct:single`                       | Logs interactions with single-type content managers.                                      |
-| `strapi:utils:url-helper`                | Logs URL helper utility operations (e.g., appending query parameters or formatting URLs). |
+| Namespace                        | Description                                                                               |
+| -------------------------------- | ----------------------------------------------------------------------------------------- |
+| `strapi:core`                    | Logs SDK initialization, configuration validation, and HTTP client setup.                 |
+| `strapi:validators:config`       | Logs details related to SDK configuration validation.                                     |
+| `strapi:validators:url`          | Logs URL validation processes.                                                            |
+| `strapi:http`                    | Logs HTTP client setup, request processing, and response/error handling.                  |
+| `strapi:auth:factory`            | Logs the registration and creation of authentication providers.                           |
+| `strapi:auth:manager`            | Logs authentication lifecycle management.                                                 |
+| `strapi:auth:provider:api-token` | Logs operations related to API token authentication.                                      |
+| `strapi:ct:collection`           | Logs interactions with collection-type content managers.                                  |
+| `strapi:ct:single`               | Logs interactions with single-type content managers.                                      |
+| `strapi:utils:url-helper`        | Logs URL helper utility operations (e.g., appending query parameters or formatting URLs). |

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export const strapi = (config: Config) => {
 
   const sdkConfig: StrapiConfig = { baseURL };
 
-  // In this factory, to keep things simple, users can't manually set the strategy options.
+  // In this factory, while there is only one auth strategy available, users can't manually set the strategy options.
   // Since the SDK constructor needs to define a proper strategy,
   // it is handled here if the auth property is provided
   if (auth !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,45 @@
+import { ApiTokenAuthProvider } from './auth';
 import { Strapi } from './sdk';
-import { StrapiConfigValidator } from './validators';
 
 import type { StrapiConfig } from './sdk';
 
 export * from './errors';
+
+export interface Config {
+  /**
+   * The base URL of the Strapi content API.
+   *
+   * This specifies where the SDK should send requests.
+   *
+   * The URL must include the protocol (`http` or `https`) and serve
+   * as the root path for all later API operations.
+   *
+   * @example
+   * 'https://api.example.com'
+   *
+   * @remarks
+   * Failing to provide a valid HTTP or HTTPS URL results in a
+   * `StrapiInitializationError`.
+   */
+  baseURL: string;
+
+  /**
+   * API token to authenticate requests (optional).
+   *
+   * When provided, this token is included in the `Authorization` header
+   * of every request to the Strapi API.
+   *
+   * @remarks
+   * - A valid token must be a non-empty string.
+   *
+   * - If the token is invalid or improperly formatted, the SDK
+   * throws a `StrapiValidationError` during initialization.
+   *
+   * - If excluded, the SDK operates without authentication.
+   */
+
+  auth?: string;
+}
 
 /**
  * Creates a new instance of the Strapi SDK with a specified configuration.
@@ -25,10 +61,7 @@ export * from './errors';
  * // Basic configuration using API token auth
  * const config = {
  *   baseURL: 'https://api.example.com',
- *   auth: {
- *     strategy: 'api-token',
- *     options: { token: 'your_token_here' }
- *   }
+ *   auth: 'your_token_here',
  * };
  *
  * // Create the SDK instance
@@ -44,13 +77,20 @@ export * from './errors';
  * @throws {StrapiInitializationError} If the provided baseURL doesn't conform to a valid HTTP or HTTPS URL,
  *                                        or if the auth configuration is invalid.
  */
-export const strapi = (config: StrapiConfig) => {
-  const configValidator = new StrapiConfigValidator();
+export const strapi = (config: Config) => {
+  const { baseURL, auth } = config;
 
-  return new Strapi<typeof config>(
-    // Properties
-    config,
-    // Dependencies
-    configValidator
-  );
+  const sdkConfig: StrapiConfig = { baseURL };
+
+  // In this factory, to keep things simple, users can't manually set the strategy options.
+  // Since the SDK constructor needs to define a proper strategy,
+  // it is handled here if the auth property is provided
+  if (auth !== undefined) {
+    sdkConfig.auth = {
+      strategy: ApiTokenAuthProvider.identifier,
+      options: { token: auth },
+    };
+  }
+
+  return new Strapi(sdkConfig);
 };

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,12 +1,13 @@
-import { strapi, StrapiInitializationError, StrapiValidationError } from '../../src';
+import { strapi, StrapiInitializationError } from '../../src';
+import { ApiTokenAuthProvider } from '../../src/auth';
 import { Strapi } from '../../src/sdk';
 
-import type { StrapiConfig } from '../../src/sdk';
+import type { Config } from '../../src';
 
 describe('strapi', () => {
-  it('should create an SDK instance with valid configuration', () => {
+  it('should create an SDK instance with valid http configuration', () => {
     // Arrange
-    const config = { baseURL: 'https://api.example.com' } satisfies StrapiConfig;
+    const config = { baseURL: 'https://api.example.com' } satisfies Config;
 
     // Act
     const sdk = strapi(config);
@@ -16,9 +17,25 @@ describe('strapi', () => {
     expect(sdk).toHaveProperty('baseURL', config.baseURL);
   });
 
+  it('should create an SDK instance with valid auth configuration', () => {
+    // Arrange
+    const token = '<token>';
+    const config = { baseURL: 'https://api.example.com', auth: token } satisfies Config;
+
+    // Act
+    const sdk = strapi(config);
+
+    // Assert
+    expect(sdk).toBeInstanceOf(Strapi);
+    expect(sdk).toHaveProperty('auth', {
+      strategy: ApiTokenAuthProvider.identifier, // default auth strategy
+      options: { token },
+    });
+  });
+
   it('should throw an error for an invalid baseURL', () => {
     // Arrange
-    const config = { baseURL: 'invalid-url' } satisfies StrapiConfig;
+    const config = { baseURL: 'invalid-url' } satisfies Config;
 
     // Act & Assert
     expect(() => strapi(config)).toThrow(StrapiInitializationError);
@@ -28,13 +45,10 @@ describe('strapi', () => {
     // Arrange
     const config = {
       baseURL: 'https://api.example.com',
-      auth: {
-        strategy: 'api-token',
-        options: { token: '' }, // Invalid token
-      },
-    } satisfies StrapiConfig;
+      auth: '', // Invalid API token
+    } satisfies Config;
 
     // Act & Assert
-    expect(() => strapi(config)).toThrow(StrapiValidationError);
+    expect(() => strapi(config)).toThrow(StrapiInitializationError);
   });
 });


### PR DESCRIPTION
### What does it do?

Simplifies the auth configuration by flattening the properties.

Basically

```typescript
strapi({
  baseURL: '...',
  auth: {
    strategy: 'api-token',
    options: {
      token: '<token>'
    }
  }
})
```

becomes

```typescript
strapi({
  baseURL: '...',
  auth: '<token>'
})
``` 

### Why is it needed?

Improve the developer experience when using the SDK

### How to test it?

See example above, it should work the same for the undocumented `users-permission` provider

