### PR TITLE
chore: ignore github messages in commitlint

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -22,6 +22,16 @@ const config: UserConfig = {
       ],
     ],
   },
+  // ignore commit messages github uses on their PR buttons, "Update" or "Merge branch"
+  ignores: [
+    (commitMessage) => {
+      // add an exception for github
+      return (
+        commitMessage.startsWith('Update ') ||
+        /^Merge branch '.*' into [a-zA-Z0-9\/\-_]+$/.test(commitMessage)
+      );
+    },
+  ],
 };
 
 export default config;


### PR DESCRIPTION
### What does it do?

Adds a rule to allow commit messages starting with "Update" or "Merge" without errors.

### Why is it needed?

To prevent commitlint errors for common GitHub commit messages.

### How to test it?

Commit with "Update" or "Merge" messages and check for no errors.

### Related issue(s)/PR(s)

N/A