### PR TITLE
enhancement(sdk): extend the public type api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,6 @@ import { Strapi } from './sdk';
 
 import type { StrapiConfig } from './sdk';
 
-export * from './errors';
-
 export interface Config {
   /**
    * The base URL of the Strapi content API.
@@ -94,3 +92,10 @@ export const strapi = (config: Config) => {
 
   return new Strapi(sdkConfig);
 };
+
+// Error classes
+export * from './errors';
+
+// Public types and interfaces
+export type { StrapiConfig, Strapi } from './sdk';
+export type { CollectionTypeManager, SingleTypeManager } from './content-types';


### PR DESCRIPTION
### What does it do?

Add four new types and interfaces to the public SDK surface:
- `Strapi` represents the sdk instance API
- `StrapiConfig` is the configuration object that is used to configure the strapi instance
- `CollectionTypeManager` is the object returned by a call to `client.collection('<ct>')`
- `SingleTypeManager` is the object returned by a call to `client.single('<st>')`

### Why is it needed?

Allow users to reference common sdk objects in their code without having to infer them from values

### How to test it?

- Build the bundles & setup the demos
- Head to the TS demo
- You should be able to import the types and use them as expected. You should not be able to use them as values.

### Related issue(s)/PR(s)

resolves https://github.com/strapi/sdk-js/issues/33