### PR TITLE
fix: send content-type as application/json when necessary

### DIFF
--- a/src/content-types/collection/manager.ts
+++ b/src/content-types/collection/manager.ts
@@ -152,7 +152,13 @@ export class CollectionTypeManager {
       url = URLHelper.appendQueryParams(url, queryParams);
     }
 
-    const response = await this._httpClient.post(url, JSON.stringify({ data }));
+    const response = await this._httpClient.post(
+      url,
+      // Wrap the payload in a data object
+      JSON.stringify({ data }),
+      // By default POST requests sets the content-type to text/plain
+      { headers: { 'Content-Type': 'application/json' } }
+    );
 
     debug('created the %o document', this._pluralName);
 
@@ -198,7 +204,13 @@ export class CollectionTypeManager {
       url = URLHelper.appendQueryParams(url, queryParams);
     }
 
-    const response = await this._httpClient.put(url, JSON.stringify({ data }));
+    const response = await this._httpClient.put(
+      url,
+      // Wrap the payload in a data object
+      JSON.stringify({ data }),
+      // By default PUT requests sets the content-type to text/plain
+      { headers: { 'Content-Type': 'application/json' } }
+    );
 
     debug('updated the %o document with id %o', this._pluralName, documentID);
 

--- a/src/content-types/single/manager.ts
+++ b/src/content-types/single/manager.ts
@@ -113,7 +113,13 @@ export class SingleTypeManager {
       url = URLHelper.appendQueryParams(url, queryParams);
     }
 
-    const response = await this._httpClient.put(url, JSON.stringify({ data }));
+    const response = await this._httpClient.put(
+      url,
+      // Wrap the payload in a data object
+      JSON.stringify({ data }),
+      // By default PUT requests sets the content-type to text/plain
+      { headers: { 'Content-Type': 'application/json' } }
+    );
 
     debug('the %o document has been updated', this._singularName);
 

--- a/tests/unit/content-types/collection/collection-manager.test.ts
+++ b/tests/unit/content-types/collection/collection-manager.test.ts
@@ -84,6 +84,9 @@ describe('CollectionTypeManager CRUD Methods', () => {
     expect(requestSpy).toHaveBeenCalledWith('/articles?locale=en', {
       method: 'POST',
       body: JSON.stringify({ data: payload }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
     });
   });
 
@@ -99,6 +102,9 @@ describe('CollectionTypeManager CRUD Methods', () => {
     expect(requestSpy).toHaveBeenCalledWith('/articles/1?locale=en', {
       method: 'PUT',
       body: JSON.stringify({ data: payload }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
     });
   });
 

--- a/tests/unit/content-types/collection/single-manager.test.ts
+++ b/tests/unit/content-types/collection/single-manager.test.ts
@@ -56,6 +56,9 @@ describe('SingleTypeManager CRUD Methods', () => {
     expect(requestSpy).toHaveBeenCalledWith('/homepage?locale=en', {
       method: 'PUT',
       body: JSON.stringify({ data: payload }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
     });
   });
 


### PR DESCRIPTION
### What does it do?

`create` and `update` need to be sent as `application/json` instead of `text/plain`

### Why is it needed?

they were failing if they weren't sent explicitly

### How to test it?

run update and create with the sdk and they should work

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
